### PR TITLE
完善新加坡节点代理组的节点名过滤规则

### DIFF
--- a/Conf/Spec/Lite.conf
+++ b/Conf/Spec/Lite.conf
@@ -61,7 +61,7 @@ keyword-filter-type = false
 🇨🇳 台湾节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇨🇳)|(台)|(Tai)|(TW)
 🇺🇲 美国节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇺🇸)|(美)|(States)|(US)
 🇯🇵 日本节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇯🇵)|(日)|(Japan)|(JP)
-🇸🇬 新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新)|(Singapore)|(SG)
+🇸🇬 新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新(?!西))|(Singapore)|(SG)
 🚀 手动选择 = select, policy-path=订阅地址, update-interval=0, no-alert=0, hidden=0, include-all-proxies=0
 
 [Rule]

--- a/Conf/Spec/Surge-CN.conf
+++ b/Conf/Spec/Surge-CN.conf
@@ -60,7 +60,7 @@ keyword-filter-type = false
 台湾节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇨🇳)|(台)|(Tai)|(TW)
 美国节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇺🇸)|(美)|(States)|(US)
 日本节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇯🇵)|(日)|(Japan)|(JP)
-新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新)|(Singapore)|(SG)
+新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新(?!西))|(Singapore)|(SG)
 手动选择 = select, policy-path=订阅地址, update-interval=0, no-alert=0, hidden=0, include-all-proxies=0
 
 [Rule]

--- a/Conf/Spec/Surge-EN.conf
+++ b/Conf/Spec/Surge-EN.conf
@@ -60,7 +60,7 @@ Microsoft = select, DIRECT, Proxy, 香港节点, 美国节点, 新加坡节点, 
 台湾节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇨🇳)|(台)|(Tai)|(TW)
 美国节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇺🇸)|(美)|(States)|(US)
 日本节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇯🇵)|(日)|(Japan)|(JP)
-新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新)|(Singapore)|(SG)
+新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新(?!西))|(Singapore)|(SG)
 手动选择 = select, policy-path=订阅地址, update-interval=0, no-alert=0, hidden=0, include-all-proxies=0
 
 [Rule]

--- a/Conf/Spec/Surge-Lite-EN.conf
+++ b/Conf/Spec/Surge-Lite-EN.conf
@@ -56,7 +56,7 @@ Gamer = select, DIRECT, Proxy, 香港节点, 美国节点, 新加坡节点, 日�
 台湾节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇨🇳)|(台)|(Tai)|(TW)
 美国节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇺🇸)|(美)|(States)|(US)
 日本节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇯🇵)|(日)|(Japan)|(JP)
-新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新)|(Singapore)|(SG)
+新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新(?!西))|(Singapore)|(SG)
 手动选择 = select, policy-path=订阅地址, update-interval=0, no-alert=0, hidden=0, include-all-proxies=0
 
 [Rule]

--- a/Conf/Spec/Surge-Mini.conf
+++ b/Conf/Spec/Surge-Mini.conf
@@ -33,7 +33,7 @@ GlobalMedia = select, 香港节点, 美国节点, 新加坡节点, 日本节点,
 台湾节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇨🇳)|(台)|(Tai)|(TW)
 美国节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇺🇸)|(美)|(States)|(US)
 日本节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇯🇵)|(日)|(Japan)|(JP)
-新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新)|(Singapore)|(SG)
+新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新(?!西))|(Singapore)|(SG)
 手动选择 = select, policy-path=订阅地址, update-interval=0, no-alert=0, hidden=0, include-all-proxies=0
 
 [Rule]

--- a/Conf/Spec/Surge.conf
+++ b/Conf/Spec/Surge.conf
@@ -63,7 +63,7 @@ keyword-filter-type = false
 🇨🇳 台湾节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇨🇳)|(台)|(Tai)|(TW)
 🇺🇲 美国节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇺🇸)|(美)|(States)|(US)
 🇯🇵 日本节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇯🇵)|(日)|(Japan)|(JP)
-🇸🇬 新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新)|(Singapore)|(SG)
+🇸🇬 新加坡节点 = fallback, policy-path=订阅地址, update-interval=0, policy-regex-filter=(🇸🇬)|(新(?!西))|(Singapore)|(SG)
 🚀 手动选择 = select, policy-path=订阅地址, update-interval=0, no-alert=0, hidden=0, include-all-proxies=0
 
 [Rule]


### PR DESCRIPTION
对于新加坡节点名的过滤方法应当补充正向否定预查，来过滤掉「新西兰」这样的地区名。